### PR TITLE
Playground: Add UI for dynamic modules

### DIFF
--- a/playground/src/css/playground.css
+++ b/playground/src/css/playground.css
@@ -8,10 +8,14 @@ body {
 #controls > fieldset {
     display: inline-block;
     margin-left: 15px;
+    border: 1px solid #999;
+    vertical-align: top;
 }
+
 #module-enabler > input {
     margin-right: 5px;
 }
+
 #module-enabler > label ~ input {
     margin-left: 15px;
 }

--- a/playground/src/css/playground.css
+++ b/playground/src/css/playground.css
@@ -5,9 +5,15 @@ body {
     font-size: 13px;
 }
 
-select {
-    width: initial;
-    margin: 0 15px;
+#controls > fieldset {
+    display: inline-block;
+    margin-left: 15px;
+}
+#module-enabler > input {
+    margin-right: 5px;
+}
+#module-enabler > label ~ input {
+    margin-left: 15px;
 }
 
 .playground-page h1,

--- a/playground/src/index.html
+++ b/playground/src/index.html
@@ -15,7 +15,16 @@
 </a>
 <h1>wasm-vips playground</h1>
 
-<select id="sample-switcher"></select>
+<section id="controls">
+  <fieldset>
+    <legend>Choose sample</legend>
+    <select id="sample-switcher"></select>
+  </fieldset>
+  <fieldset id="module-enabler">
+    <legend>Enable dynamic modules</legend>
+  </fieldset>
+</section>
+
 <section id="playground"></section>
 
 <footer>

--- a/playground/src/index.js
+++ b/playground/src/index.js
@@ -191,7 +191,7 @@ function load () {
     url.searchParams.set('modules', [...enabledModules].join('-'));
     // Reload the page to change settings, but pretend the reload never happened
     history.replaceState({}, '', url);
-    if(reload){
+    if (reload) {
       share();
       window.location.reload();
     }

--- a/playground/src/index.js
+++ b/playground/src/index.js
@@ -168,7 +168,7 @@ function load () {
       checkbox.checked = true;
     }
     checkbox.addEventListener('change', event => {
-      toggleModuleInUrl(dynamicModule.id, event.target.checked);
+      toggleModuleInUrl(dynamicModule.id, event.target.checked, true);
     });
 
     moduleEnabler.append(checkbox, checkboxLabel);
@@ -181,7 +181,7 @@ function load () {
 
     return { url, isSet, enabledModules };
   }
-  function toggleModuleInUrl (id, state) {
+  function toggleModuleInUrl (id, state, reload = false) {
     const { url, enabledModules } = getEnabledModulesFromUrl();
     if (state) {
       enabledModules.add(id);
@@ -191,8 +191,10 @@ function load () {
     url.searchParams.set('modules', [...enabledModules].join('-'));
     // Reload the page to change settings, but pretend the reload never happened
     history.replaceState({}, '', url);
-    share();
-    window.location.reload();
+    if(reload){
+      share();
+      window.location.reload();
+    }
   }
 
   const sampleSwitcher = document.getElementById('sample-switcher');

--- a/playground/src/playground-runner.html
+++ b/playground/src/playground-runner.html
@@ -17,6 +17,22 @@
 <body>
 <script src="/lib/vips.js?<%= __webpack_hash__ %>"></script>
 <script type="module">
+  // TODO: `dynamicModules` should be imported from './samples' instead.
+  const dynamicModules = [
+    {
+      id: "jxl",
+      file: "vips-jxl.wasm",
+    },
+    {
+      id: "heif",
+      file: "vips-heif.wasm",
+    },
+    {
+      id: "resvg",
+      file: "vips-resvg.wasm",
+    },
+  ];
+
   let loadedElements = [];
 
   window.addEventListener('message', load);
@@ -112,12 +128,8 @@
   // Control the dynamic modules via the ?modules= query string
   const params = new URL(document.referrer).searchParams;
   if (params.has('modules')) {
-    const enabledModules = params.get('modules').split(',').filter(e => e);
-    options.dynamicLibraries = [
-      'vips-jxl.wasm', // enabled by default
-      'vips-heif.wasm', // enabled by default
-      'vips-resvg.wasm' // disabled by default
-    ].filter(m => enabledModules.some(e => m.includes(e)));
+    const enabledModules = params.get('modules').split('-').filter(id => id.length > 2);
+    options.dynamicLibraries = dynamicModules.filter(module => enabledModules.some(id => module.id === id)).map(module => module.file);
   }
 
   globalThis.vips = await Vips(options);

--- a/playground/src/samples.js
+++ b/playground/src/samples.js
@@ -8,6 +8,27 @@ import './images/banana.gif';
 import './images/alphachannel.svg';
 import './images/transparency_demo.png';
 
+export const dynamicModules = [
+  {
+    name: 'JPEG XL save/load',
+    id: 'jxl',
+    file: 'vips-jxl.wasm',
+    default: true
+  },
+  {
+    name: 'AVIF save/load',
+    id: 'heif',
+    file: 'vips-heif.wasm',
+    default: true
+  },
+  {
+    name: 'SVG load (no text support)',
+    id: 'resvg',
+    file: 'vips-resvg.wasm',
+    default: false
+  }
+];
+
 export const playSamples = [
   {
     chapter: 'Filter',


### PR DESCRIPTION
Adds controls to the playground which allow you to enable/disable the dynamic modules. Builds on the work done in 5f2af119c1400f46102af9498d69deceed23200a.

![image](https://user-images.githubusercontent.com/20535393/219524978-ae85d5bb-5311-4d04-831e-75718d952d53.jpg)

I was trying to test the new SVG support, and it took me a few hours to figure out why it didn't work. This UI would have saved me a lot of time 😅

It's a little rough around the edges,  but I think it's fine at least as a v1. LMK if there is something you really want me to fix before merging.
Another note: I was not able to import `dynamicModules` from  `samples.js` in `playground-runner.html`, so I have manually copied part of the object into the file. It isn't a great solution, but it isn't worse than the existing one.