### PR TITLE
imagequant: drop patch now accepted upstream

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -351,8 +351,6 @@ node --version
   mkdir $DEPS/imagequant
   curl -Ls https://github.com/lovell/libimagequant/archive/refs/tags/v$VERSION_IMAGEQUANT.tar.gz | tar xzC $DEPS/imagequant --strip-components=1
   cd $DEPS/imagequant
-  # TODO(kleisauke): Discuss this patch upstream
-  curl -Ls https://github.com/lovell/libimagequant/compare/v$VERSION_IMAGEQUANT...kleisauke:wasm-vips.patch | patch -p1
   meson setup _build --prefix=$TARGET --cross-file=$MESON_CROSS --default-library=static --buildtype=release \
     ${ENABLE_SIMD:+-Dc_args="$CFLAGS -msse -DUSE_SSE=1"}
   meson install -C _build --tag devel


### PR DESCRIPTION
I've added your patch upstream via https://github.com/lovell/libimagequant/commit/bdff55ed976b36bee558ed737604a1887f6c388e