### PR TITLE
feat: slim and lowmem versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 # wasm-vips
 
 [libvips](https://libvips.github.io/libvips) for the browser and Node.js,
@@ -14,7 +15,44 @@ and because it doesn't need to keep entire images in memory, it's light.
 > This library is still under early development. See: [#1](
 https://github.com/kleisauke/wasm-vips/issues/1).
 
-## Engine support
+
+## Package Variants
+
+This **fork** of [`wasm-vips`](https://github.com/kleisauke/wasm-vips) provides different binaries in a single package to cater to different needs. Each variant is optimized for specific scenarios:
+- **`@denodecom/wasm-vips`**: The default build with full features and SIMD support.
+  - Supports all loaders.
+
+- **`@denodecom/wasm-vips/nosimd`**: Build without SIMD support.
+  - Supports all loaders.
+
+- **`@denodecom/wasm-vips/slim`**: A build with reduced features and memory usage.
+  - Supports only JPEG, PNG, and WebP loaders.
+  - Filesystem (FS) support is not available
+
+- **`@denodecom/wasm-vips/nosimd/slim`**: A slim build without SIMD support.
+  - Supports only JPEG, PNG, and WebP loaders.
+  - Filesystem (FS) support is not available
+
+- **`@denodecom/wasm-vips/lowmem`**: A build optimized for low memory usage with a maximum memory limit of 256MB to avoid out-of-memory (OOM) issues on iOS.
+  - Supports all loaders.
+
+- **`@denodecom/wasm-vips/nosimd/lowmem`**: A low memory build without SIMD support, with a maximum memory limit of 256MB to avoid out-of-memory (OOM) issues on iOS.
+  - Supports all loaders.
+
+
+
+### Low Memory Builds
+
+- **`./lowmem`**: A build optimized for low memory usage.
+  - **Browser**: `./lib/lowmem/vips-es6.js` (ES6 Module) or `./lib/lowmem/vips.js` (CommonJS Module)
+  - **Node.js**: `./lib/lowmem/vips-node.mjs` (ES6 Module) or `./lib/lowmem/vips-node.js` (CommonJS Module)
+
+- **`./nosimd/lowmem`**: A low memory build without SIMD support.
+  - **Browser**: `./lib/nosimd/lowmem/vips-es6.js` (ES6 Module) or `./lib/nosimd/lowmem/vips.js` (CommonJS Module)
+  - **Node.js**: `./lib/nosimd/lowmem/vips-node.mjs` (ES6 Module) or `./lib/nosimd/lowmem/vips-node.js` (CommonJS Module)
+
+
+## Engine support for default build
 
 An engine that [supports WebAssembly SIMD](https://webassembly.org/roadmap/).
 This is present on most major browser engines.
@@ -34,14 +72,14 @@ at least version 615.1.17 is required. This corresponds to Safari 16.4.
 
 ## Installation
 
-wasm-vips can be installed with your favorite package manager.
+`@denodecom/wasm-vips` can be installed with your favorite package manager.
 
 ```shell
-npm install wasm-vips
+npm install @denodecom/wasm-vips
 ```
 
 ```shell
-yarn add wasm-vips
+yarn add @denodecom/wasm-vips
 ```
 
 ## Usage
@@ -89,10 +127,10 @@ can be imported as both CommonJS and ES6 module:
 
 ```js
 // ES6 module
-import Vips from 'wasm-vips';
+import Vips from '@denodecom/wasm-vips';
 
 // CommonJS module
-const Vips = require('wasm-vips');
+const Vips = require('@denodecom/wasm-vips');
 ```
 
 Then, wasm-vips can be initialized like this:
@@ -109,11 +147,8 @@ Vips().then(vips => {
 
 ### Deno
 
-On Deno, the web ES6 module can be reused and imported from a CDN such as
-[jsDelivr](https://www.jsdelivr.com/):
-
 ```js
-import Vips from 'https://cdn.jsdelivr.net/npm/wasm-vips/lib/vips-es6.js';
+import Vips from 'npm:@denodecom/wasm-vips';
 
 const vips = await Vips();
 ```

--- a/build.sh
+++ b/build.sh
@@ -149,7 +149,12 @@ fi
 export RUSTFLAGS="-Ctarget-feature=+atomics,+bulk-memory,+nontrapping-fptoint -Zdefault-hidden-visibility=yes"
 
 # Common compiler flags
-COMMON_FLAGS="-Oz -pthread"
+if [ $SLIM_BUILD = "true" ]; then
+  COMMON_FLAGS="-Oz -pthread"
+else
+  COMMON_FLAGS="-O3 -pthread"
+fi
+
 if [ "$LTO" = "true" ]; then
   COMMON_FLAGS+=" -flto"
   export RUSTFLAGS+=" -Clto -Cembed-bitcode=yes"

--- a/build.sh
+++ b/build.sh
@@ -14,6 +14,9 @@ SOURCE_DIR=$PWD
 # Specifies the environment(s) to target
 ENVIRONMENT="web,node"
 
+# Enable slim build with reduced features and memory usage
+SLIM_BUILD=false
+
 # Fixed-width SIMD, enabled by default
 # https://github.com/WebAssembly/simd
 SIMD=true
@@ -98,6 +101,7 @@ while [ $# -gt 0 ]; do
     -e|--environment) ENVIRONMENT="$2"; shift ;;
     --variant) BUILD_VARIANT="$2"; shift ;;
     --clean-build) CLEAN_BUILD=true ;;
+    --slim) SLIM_BUILD=true ;;
     *) echo "ERROR: Unknown parameter: $1" >&2; exit 1 ;;
   esac
   shift
@@ -542,7 +546,8 @@ node --version
   mkdir $DEPS/wasm-vips
   cd $DEPS/wasm-vips
   emcmake cmake $SOURCE_DIR -DCMAKE_BUILD_TYPE=Release -DCMAKE_RUNTIME_OUTPUT_DIRECTORY="$OUTPUT_DIR" \
-    -DENVIRONMENT=${ENVIRONMENT//,/;} -DENABLE_MODULES=$MODULES -DENABLE_WASMFS=$WASM_FS -DENABLE_FS=$FS
+    -DENVIRONMENT=${ENVIRONMENT//,/;} -DENABLE_MODULES=$MODULES -DENABLE_WASMFS=$WASM_FS -DENABLE_FS=$FS \
+    -DSLIM_BUILD=${SLIM_BUILD}
   make
 )
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "wasm-vips",
+  "name": "@denodecom/wasm-vips",
   "version": "0.0.9",
   "description": "libvips for the browser and Node.js, compiled to WebAssembly with Emscripten",
   "homepage": "https://github.com/kleisauke/wasm-vips",
@@ -25,6 +25,17 @@
       },
       "default": "./lib/vips.js"
     },
+    "./nosimd": {
+      "browser": {
+        "import": "./lib/nosimd/vips-es6.js",
+        "require": "./lib/nosimd/vips.js"
+      },
+      "node": {
+        "import": "./lib/nosimd/vips-node.mjs",
+        "require": "./lib/nosimd/vips-node.js"
+      },
+      "default": "./lib/nosimd/vips.js"
+    },
     "./versions": "./versions.json"
   },
   "main": "lib/vips-node.js",
@@ -39,11 +50,16 @@
     "lib/vips-jxl.wasm",
     "lib/vips-resvg.wasm",
     "THIRD-PARTY-NOTICES.md",
-    "versions.json"
+    "versions.json",
+    "lib/nosimd/*"
   ],
   "scripts": {
-    "build": "docker build -t wasm-vips . && docker run -it --rm -v $(pwd):/src wasm-vips ./build.sh",
-    "test": "npm run test:lint && npm run test:node",
+    "build:base": "docker build -t wasm-vips . && docker run -it --rm -v $(pwd):/src wasm-vips ./build.sh --clean-build",
+    "build:nosimd": "docker build -t wasm-vips . && docker run -it --rm -v $(pwd):/src wasm-vips ./build.sh --clean-build --variant nosimd --disable-simd",
+    "build": "npm run build:base && npm run build:nosimd",
+    "test": "npm run test:lint && npm run test:base && npm run test:nosimd",
+    "test:base": "npm run test:node",
+    "test:nosimd": "VARIANT=nosimd npm run test:node",
     "test:lint": "semistandard",
     "test:node": "npm --prefix test/unit test",
     "test:web": "serve -c test/unit/serve.json",
@@ -52,6 +68,8 @@
     "bench:web": "serve -c test/bench/serve.json"
   },
   "devDependencies": {
+    "chai": "^5.1.1",
+    "mocha": "^10.4.0",
     "semistandard": "^17.0.0",
     "serve": "^14.2.3"
   },

--- a/package.json
+++ b/package.json
@@ -36,6 +36,17 @@
       },
       "default": "./lib/nosimd/vips.js"
     },
+    "./slim": {
+      "browser": {
+        "import": "./lib/slim/vips-es6.js",
+        "require": "./lib/slim/vips.js"
+      },
+      "node": {
+        "import": "./lib/slim/vips-node.mjs",
+        "require": "./lib/slim/vips-node.js"
+      },
+      "default": "./lib/slim/vips.js"
+    },
     "./versions": "./versions.json"
   },
   "main": "lib/vips-node.js",
@@ -55,11 +66,12 @@
   ],
   "scripts": {
     "build:base": "docker build -t wasm-vips . && docker run -it --rm -v $(pwd):/src wasm-vips ./build.sh --clean-build",
+    "build:slim": "docker build -t wasm-vips . && docker run -it --rm -v $(pwd):/src wasm-vips ./build.sh --variant slim --disable-modules --disable-jxl --disable-avif --disable-svg --disable-analyze --disable-radiance --disable-ppm --disable-gif --disable-tiff --disable-fs",
     "build:nosimd": "docker build -t wasm-vips . && docker run -it --rm -v $(pwd):/src wasm-vips ./build.sh --clean-build --variant nosimd --disable-simd",
-    "build": "npm run build:base && npm run build:nosimd",
-    "test": "npm run test:lint && npm run test:base && npm run test:nosimd",
-    "test:base": "npm run test:node",
-    "test:nosimd": "VARIANT=nosimd npm run test:node",
+    "build": "npm run build:base && npm run build:slim && npm run build:nosimd",
+    "test": "npm run test:lint && npm run test:base && npm run test:nosimd && npm run test:slim",
+    "test:slim": "npm run test:lint && VARIANT=slim npm run test:node",
+    "test:nosimd": "npm run test:lint && VARIANT=nosimd npm run test:node",
     "test:lint": "semistandard",
     "test:node": "npm --prefix test/unit test",
     "test:web": "serve -c test/unit/serve.json",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,28 @@
       },
       "default": "./lib/vips.js"
     },
+    "./nosimd/slim": {
+      "browser": {
+        "import": "./lib/nosimd/slim/vips-es6.js",
+        "require": "./lib/nosimd/slim/vips.js"
+      },
+      "node": {
+        "import": "./lib/nosimd/slim/vips-node.mjs",
+        "require": "./lib/nosimd/slim/vips-node.js"
+      },
+      "default": "./lib/nosimd/slim/vips.js"
+    },
+    "./nosimd/lowmem": {
+      "browser": {
+        "import": "./lib/nosimd/lowmem/vips-es6.js",
+        "require": "./lib/nosimd/lowmem/vips.js"
+      },
+      "node": {
+        "import": "./lib/nosimd/lowmem/vips-node.mjs",
+        "require": "./lib/nosimd/lowmem/vips-node.js"
+      },
+      "default": "./lib/nosimd/lowmem/vips.js"
+    },
     "./nosimd": {
       "browser": {
         "import": "./lib/nosimd/vips-es6.js",
@@ -35,6 +57,17 @@
         "require": "./lib/nosimd/vips-node.js"
       },
       "default": "./lib/nosimd/vips.js"
+    },
+    "./lowmem": {
+      "browser": {
+        "import": "./lib/lowmem/vips-es6.js",
+        "require": "./lib/lowmem/vips.js"
+      },
+      "node": {
+        "import": "./lib/lowmem/vips-node.mjs",
+        "require": "./lib/lowmem/vips-node.js"
+      },
+      "default": "./lib/lowmem/vips.js"
     },
     "./slim": {
       "browser": {
@@ -65,13 +98,24 @@
     "lib/nosimd/*"
   ],
   "scripts": {
-    "build:base": "docker build -t wasm-vips . && docker run -it --rm -v $(pwd):/src wasm-vips ./build.sh --clean-build",
-    "build:slim": "docker build -t wasm-vips . && docker run -it --rm -v $(pwd):/src wasm-vips ./build.sh --variant slim --disable-modules --disable-jxl --disable-avif --disable-svg --disable-analyze --disable-radiance --disable-ppm --disable-gif --disable-tiff --disable-fs",
-    "build:nosimd": "docker build -t wasm-vips . && docker run -it --rm -v $(pwd):/src wasm-vips ./build.sh --clean-build --variant nosimd --disable-simd",
-    "build": "npm run build:base && npm run build:slim && npm run build:nosimd",
-    "test": "npm run test:lint && npm run test:base && npm run test:nosimd && npm run test:slim",
-    "test:slim": "npm run test:lint && VARIANT=slim npm run test:node",
-    "test:nosimd": "npm run test:lint && VARIANT=nosimd npm run test:node",
+    "build:base": "docker build -t wasm-vips . && docker run -it --rm -v $(pwd):/src wasm-vips ./build.sh",
+    "build:slim": "docker build -t wasm-vips . && docker run -it --rm -v $(pwd):/src wasm-vips ./build.sh --slim --variant slim --disable-modules --disable-jxl --disable-avif --disable-svg --disable-analyze --disable-radiance --disable-ppm --disable-gif --disable-tiff --disable-fs",
+    "build:lowmem": "docker build -t wasm-vips . && docker run -it --rm -v $(pwd):/src wasm-vips ./build.sh --slim --variant lowmem",
+    "build:nosimd:slim": "npm run build:slim -- --variant nosimd/slim --disable-simd",
+    "build:nosimd:lowmem": "npm run build:lowmem -- --variant nosimd/lowmem --disable-simd",
+    "build:nosimd": "npm run build:base -- --variant nosimd --disable-simd",
+    "build": "npm run build:all:base && npm run build:all:nosimd",
+    "build:all:base": "npm run build:base -- --clean-build && npm run build:slim -- --clean-build && npm run build:lowmem -- --clean-build",
+    "build:all:nosimd": "npm run build:nosimd -- --clean-build && npm run build:nosimd:slim -- --clean-build && npm run build:nosimd:lowmem -- --clean-build",
+    "test": "npm run test:lint && npm run test:all:base && npm run test:all:nosimd",
+    "test:all:base": "npm run test:base && npm run test:lowmem && npm run test:slim",
+    "test:all:nosimd": "npm run test:nosimd && npm run test:nosimd:lowmem && npm run test:nosimd:slim",
+    "test:base": "npm run test:node",
+    "test:lowmem": "VARIANT=lowmem npm run test:node",
+    "test:slim": "VARIANT=slim npm run test:node",
+    "test:nosimd:lowmem": "VARIANT=nosimd/lowmem npm run test:node",
+    "test:nosimd:slim": "VARIANT=nosimd/slim npm run test:node",
+    "test:nosimd": "VARIANT=nosimd npm run test:node",
     "test:lint": "semistandard",
     "test:node": "npm --prefix test/unit test",
     "test:web": "serve -c test/unit/serve.json",

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,3 +1,5 @@
+option(SLIM_BUILD "Enable slim build with reduced memory usage" OFF)
+
 set(HEADERS
         bindings/connection.h
         bindings/error.h
@@ -96,9 +98,6 @@ endif()
 set(MAIN_COMPILE_OPTIONS
         $<$<BOOL:${ENABLE_MODULES}>:-sMAIN_MODULE=2>
         )
-set(MAIN_COMPILE_OPTIONS
-        $<$<BOOL:${ENABLE_FS}>:-sFORCE_FILESYSTEM=1>
-        )
 
 # Handy for debugging
 # --threadprofiler
@@ -132,7 +131,8 @@ set(MAIN_LINK_OPTIONS
         -sMODULARIZE
         -sEXPORT_NAME='Vips'
         -sEXIT_RUNTIME
-        -sINITIAL_MEMORY=1GB
+        $<$<NOT:$<BOOL:${SLIM_BUILD}>>:-sINITIAL_MEMORY=1GB>
+        $<$<BOOL:${SLIM_BUILD}>:-sINITIAL_MEMORY=256MB>
         -sSTACK_SIZE=256KB
         -sALLOW_TABLE_GROWTH
         -sALLOW_BLOCKING_ON_MAIN_THREAD

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -96,6 +96,9 @@ endif()
 set(MAIN_COMPILE_OPTIONS
         $<$<BOOL:${ENABLE_MODULES}>:-sMAIN_MODULE=2>
         )
+set(MAIN_COMPILE_OPTIONS
+        $<$<BOOL:${ENABLE_FS}>:-sFORCE_FILESYSTEM=1>
+        )
 
 # Handy for debugging
 # --threadprofiler
@@ -120,6 +123,8 @@ set(MAIN_LINK_OPTIONS
         -lembind
         $<$<BOOL:${ENABLE_WASMFS}>:-sWASMFS>
         $<$<BOOL:${ENABLE_MODULES}>:-sMAIN_MODULE=2>
+        $<$<BOOL:${ENABLE_FS}>:-sFORCE_FILESYSTEM=1>
+        $<$<NOT:$<BOOL:${ENABLE_FS}>>:-sFORCE_FILESYSTEM=0>
         $<$<BOOL:${ENABLE_MODULES}>:--pre-js=${CMAKE_CURRENT_SOURCE_DIR}/modules-pre.js>
         -sAUTOLOAD_DYLIBS=0
         -sABORTING_MALLOC=0
@@ -133,8 +138,8 @@ set(MAIN_LINK_OPTIONS
         -sALLOW_BLOCKING_ON_MAIN_THREAD
         -sTEXTDECODER=2
         -sASSERTIONS=0
-        -sFORCE_FILESYSTEM
-        -sEXPORTED_RUNTIME_METHODS=FS,ENV,deletionQueue,addFunction,bigintToI53Checked
+        $<$<BOOL:${ENABLE_FS}>:-sEXPORTED_RUNTIME_METHODS=FS,ENV,deletionQueue,addFunction,bigintToI53Checked>
+        $<$<NOT:$<BOOL:${ENABLE_FS}>>:-sEXPORTED_RUNTIME_METHODS=ENV,deletionQueue,addFunction,bigintToI53Checked>
         -sEXCEPTION_STACK_TRACES
         -sBINARYEN_EXTRA_PASSES=--emit-target-features
         )

--- a/test/unit/node-helper.js
+++ b/test/unit/node-helper.js
@@ -1,11 +1,16 @@
 'use strict';
 
-import Vips from '../../lib/vips-node.mjs';
-
 import { tmpdir } from 'node:os';
 import { expect } from 'chai';
 
 globalThis.expect = expect;
+
+const variant = process.argv
+  .find(arg => arg.startsWith('--variant='))
+  ?.split('=')?.[1];
+const pkg = variant ? `../../lib/${variant}/vips-node.mjs` : '../../lib/vips-node.mjs';
+
+const { default: Vips } = await import(pkg);
 
 export async function mochaGlobalSetup () {
   const options = {

--- a/test/unit/node-helper.js
+++ b/test/unit/node-helper.js
@@ -13,7 +13,6 @@ const pkg = variant ? `../../lib/${variant}/vips-node.mjs` : '../../lib/vips-nod
 const { default: Vips } = await import(pkg);
 
 export async function mochaGlobalSetup () {
-
   // Test all available dynamic modules for non lowmem/slim builds
   const dynamicLibraries = /(lowmem|slim)$/.test(variant) ? [] : ['vips-jxl.wasm', 'vips-heif.wasm', 'vips-resvg.wasm'];
 

--- a/test/unit/node-helper.js
+++ b/test/unit/node-helper.js
@@ -13,11 +13,12 @@ const pkg = variant ? `../../lib/${variant}/vips-node.mjs` : '../../lib/vips-nod
 const { default: Vips } = await import(pkg);
 
 export async function mochaGlobalSetup () {
+
+  // Test all available dynamic modules for non lowmem/slim builds
+  const dynamicLibraries = /(lowmem|slim)$/.test(variant) ? [] : ['vips-jxl.wasm', 'vips-heif.wasm', 'vips-resvg.wasm'];
+
   const options = {
-    // Uncomment to disable dynamic modules
-    // dynamicLibraries: [],
-    // Test all available dynamic modules
-    dynamicLibraries: ['vips-jxl.wasm', 'vips-heif.wasm', 'vips-resvg.wasm'],
+    dynamicLibraries,
     preRun: (module) => {
       module.setAutoDeleteLater(true);
       module.setDelayFunction(fn => {

--- a/test/unit/package.json
+++ b/test/unit/package.json
@@ -16,7 +16,7 @@
   "author": "Kleis Auke Wolthuizen",
   "type": "module",
   "scripts": {
-    "test": "mocha -s 5000 -t 120000 *.js -r node-helper.js"
+    "test": "mocha -s 5000 -t 120000 *.js -r node-helper.js --variant=$VARIANT"
   },
   "devDependencies": {
     "chai": "^5.1.1",

--- a/test/unit/test_connection.js
+++ b/test/unit/test_connection.js
@@ -29,6 +29,9 @@ describe('connection', () => {
 
   describe('source', () => {
     it('newFromFile', function () {
+      if (!vips.FS) {
+        return this.skip();
+      }
       const x = vips.Source.newFromFile(Helpers.jpegFile);
 
       expect(x.filename).to.equal(Helpers.jpegFile);
@@ -43,6 +46,9 @@ describe('connection', () => {
 
   describe('target', () => {
     it('newToFile', function () {
+      if (!vips.FS) {
+        return this.skip();
+      }
       const filename = vips.Utils.tempName('%s.jpg');
       const x = vips.Target.newToFile(filename);
 
@@ -79,6 +85,9 @@ describe('connection', () => {
         expect(y.height).to.equal(442);
       });
       it('custom', function () {
+        if (!vips.FS) {
+          return this.skip();
+        }
         const stream = vips.FS.open(Helpers.jpegFile, 'r');
 
         const source = new vips.SourceCustom();
@@ -101,6 +110,9 @@ describe('connection', () => {
     });
     describe('writeToTarget', () => {
       it('file', function () {
+        if (!vips.FS) {
+          return this.skip();
+        }
         const filename = vips.Utils.tempName('%s.jpg');
 
         const x = vips.Target.newToFile(filename);
@@ -122,6 +134,9 @@ describe('connection', () => {
         expect(x.getBlob()).to.deep.equal(y);
       });
       it('custom', function () {
+        if (!vips.FS) {
+          return this.skip();
+        }
         const filename = vips.Utils.tempName('%s.png');
         const stream = vips.FS.open(filename, 'w');
 

--- a/test/unit/test_foreign.js
+++ b/test/unit/test_foreign.js
@@ -59,7 +59,11 @@ describe('foreign', () => {
     cmyk = cmyk.copy({ interpretation: vips.Interpretation.cmyk });
     cmyk.remove('icc-profile-data');
 
-    const im = vips.Image.newFromFile(Helpers.gifFile);
+    const [file] = [
+      Helpers.have('gifload') && Helpers.gifFile,
+      Helpers.have('pngload') && Helpers.pngFile
+    ].filter(Boolean);
+    const im = vips.Image.newFromFile(file);
     onebit = im.extractBand(1).more(128);
 
     globalDeletionQueue = vips.deletionQueue.splice(0);

--- a/test/unit/test_foreign.js
+++ b/test/unit/test_foreign.js
@@ -2,6 +2,7 @@
 'use strict';
 
 import * as Helpers from './helpers.js';
+import fs from 'fs';
 
 describe('foreign', () => {
   let globalDeletionQueue;
@@ -87,7 +88,7 @@ describe('foreign', () => {
   }
 
   function bufferLoader (loader, testFile, validate) {
-    const buf = vips.FS.readFile(testFile);
+    const buf = fs.readFileSync(testFile);
 
     let im = bufferLoaders[loader](buf);
     validate(im);
@@ -151,6 +152,9 @@ describe('foreign', () => {
   }
 
   it('vips', function () {
+    if (!vips.FS) {
+      return this.skip();
+    }
     // ftruncate() is not yet available in the Node backend of WasmFS.
     // https://github.com/emscripten-core/emscripten/blob/3.1.48/system/lib/wasmfs/backends/node_backend.cpp#L120-L122
     if (typeof vips.FS.statBufToObject === 'function') {

--- a/test/unit/test_iofuncs.js
+++ b/test/unit/test_iofuncs.js
@@ -64,6 +64,9 @@ describe('iofuncs', () => {
   });
 
   it('revalidate', function () {
+    if (!vips.FS) {
+      return this.skip();
+    }
     // ftruncate() is not yet available in the Node backend of WasmFS.
     // https://github.com/emscripten-core/emscripten/blob/3.1.48/system/lib/wasmfs/backends/node_backend.cpp#L120-L122
     if (typeof vips.FS.statBufToObject === 'function') {

--- a/test/unit/test_resample.js
+++ b/test/unit/test_resample.js
@@ -227,10 +227,15 @@ describe('resample', () => {
     expect(im.width).to.equal(100);
     expect(im.height).to.equal(300);
 
-    let im1 = vips.Image.thumbnail(Helpers.jpegFile, 100);
-    let buf = vips.FS.readFile(Helpers.jpegFile);
-    let im2 = vips.Image.thumbnailBuffer(buf, 100);
-    expect(Math.abs(im1.avg() - im2.avg())).to.be.below(1);
+    let im1;
+    let buf;
+    let im2;
+    if (vips.FS) {
+      im1 = vips.Image.thumbnail(Helpers.jpegFile, 100);
+      buf = vips.FS.readFile(Helpers.jpegFile);
+      im2 = vips.Image.thumbnailBuffer(buf, 100);
+      expect(Math.abs(im1.avg() - im2.avg())).to.be.below(1);
+    }
 
     // Needs TIFF support
     if (Helpers.have('tiffload')) {


### PR DESCRIPTION
This PR adds the following variants to support low memory devices, especially iOS. See [this WebKit bug](https://bugs.webkit.org/show_bug.cgi?id=222097) for more information:

- **`@denodecom/wasm-vips/slim`**: A build with reduced features and memory usage.
  - Supports only JPEG, PNG, and WebP loaders.
  - Filesystem (FS) support is not available

- **`@denodecom/wasm-vips/nosimd/slim`**: A slim build without SIMD support.
  - Supports only JPEG, PNG, and WebP loaders.
  - Filesystem (FS) support is not available

- **`@denodecom/wasm-vips/lowmem`**: A build optimized for low memory usage with a maximum memory limit of 256MB to avoid out-of-memory (OOM) issues on iOS.
  - Supports all loaders.

- **`@denodecom/wasm-vips/nosimd/lowmem`**: A low memory build without SIMD support, with a maximum memory limit of 256MB to avoid out-of-memory (OOM) issues on iOS.
  - Supports all loaders.