### PR TITLE
Document optional libraries for GPLv2-compatible builds

### DIFF
--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -39,11 +39,10 @@ The following libraries are optional and can be disabled during build:
 |---------------|-------------------|-----------------------------------------------|
 | aom + libheif | `--disable-avif`  | Disables AVIF/HEIF image support              |
 | libultrahdr   | `--disable-uhdr`  | Disables UltraHDR image support               |
-| libexif       | `--disable-exif`  | Disables EXIF metadata support                |
 | libjxl        | `--disable-jxl`   | Disables JPEG XL image support                |
 | resvg         | `--disable-svg`   | Disables SVG image support                    |
 
-For a GPLv2-compatible build, use: `./build.sh --disable-avif --disable-uhdr --disable-exif`
+For a GPLv2-compatible build, use: `./build.sh --disable-avif --disable-uhdr`
 
 Please report any errors or omissions via
 https://github.com/kleisauke/wasm-vips/issues/new

--- a/build.sh
+++ b/build.sh
@@ -63,9 +63,6 @@ AVIF=true
 # Partial support for SVG load via resvg, enabled by default
 SVG=true
 
-# Support for EXIF metadata via libexif, enabled by default
-EXIF=true
-
 # Build libvips C++ API, disabled by default
 LIBVIPS_CPP=false
 
@@ -88,7 +85,6 @@ while [ $# -gt 0 ]; do
     --disable-jxl) JXL=false ;;
     --disable-avif) AVIF=false ;;
     --disable-svg) SVG=false ;;
-    --disable-exif) EXIF=false ;;
     --disable-modules) MODULES=false ;;
     --disable-bindings) BINDINGS=false ;;
     --enable-libvips-cpp) LIBVIPS_CPP=true ;;
@@ -99,7 +95,7 @@ while [ $# -gt 0 ]; do
 done
 
 # Configure the ENABLE_* and DISABLE_* expansion helpers
-for arg in SIMD UHDR JXL AVIF SVG EXIF MODULES BINDINGS; do
+for arg in SIMD UHDR JXL AVIF SVG MODULES BINDINGS; do
   if [ "${!arg}" = "true" ]; then
     declare ENABLE_$arg=true
   else
@@ -206,7 +202,7 @@ VERSION_EMSCRIPTEN="$(emcc -dumpversion)"
   [ -n "$DISABLE_JXL" ] || printf "  \"brotli\": \"${VERSION_BROTLI}\",\n"; \
   printf "  \"cgif\": \"${VERSION_CGIF}\",\n"; \
   printf "  \"emscripten\": \"${VERSION_EMSCRIPTEN}\",\n"; \
-  [ -n "$DISABLE_EXIF" ] || printf "  \"exif\": \"${VERSION_EXIF}\",\n"; \
+  printf "  \"exif\": \"${VERSION_EXIF}\",\n"; \
   printf "  \"expat\": \"${VERSION_EXPAT}\",\n"; \
   printf "  \"ffi\": \"${VERSION_FFI}\",\n"; \
   printf "  \"glib\": \"${VERSION_GLIB}\",\n"; \
@@ -299,7 +295,7 @@ node --version
   make install dist_cmake_DATA= nodist_cmake_DATA=
 )
 
-[ -f "$TARGET/lib/pkgconfig/libexif.pc" ] || [ -n "$DISABLE_EXIF" ] || (
+[ -f "$TARGET/lib/pkgconfig/libexif.pc" ] || (
   stage "Compiling exif"
   mkdir $DEPS/exif
   curl -Ls https://github.com/libexif/libexif/releases/download/v$VERSION_EXIF/libexif-$VERSION_EXIF.tar.xz | tar xJC $DEPS/exif --strip-components=1
@@ -517,7 +513,7 @@ node --version
   meson setup _build --prefix=$TARGET $MESON_ARGS --default-library=static --buildtype=release \
     -Ddeprecated=false -Dexamples=false -Dcplusplus=$LIBVIPS_CPP -Dauto_features=enabled \
     -Dintrospection=disabled ${DISABLE_MODULES:+-Dmodules=disabled} -Darchive=disabled \
-    -Dcfitsio=disabled ${DISABLE_EXIF:+-Dexif=disabled} -Dfftw=disabled -Dfontconfig=disabled ${DISABLE_AVIF:+-Dheif=disabled} \
+    -Dcfitsio=disabled -Dfftw=disabled -Dfontconfig=disabled ${DISABLE_AVIF:+-Dheif=disabled} \
     ${DISABLE_SIMD:+-Dhighway=disabled} ${DISABLE_JXL:+-Djpeg-xl=disabled} -Dmagick=disabled \
     -Dmatio=disabled -Dnifti=disabled -Dopenexr=disabled -Dopenjpeg=disabled \
     -Dopenslide=disabled -Dpangocairo=disabled -Dpdfium=disabled -Dpoppler=disabled \


### PR DESCRIPTION
## Summary

- Document optional libraries and how to disable them in THIRD-PARTY-NOTICES.md
- Enable creation of GPLv2-compatible builds by excluding libraries with incompatible licenses

## GPLv2-Compatible Build

For projects that require GPLv2 compatibility, the following libraries can be excluded:

```bash
./build.sh --disable-avif --disable-uhdr
```

This excludes:
- **libheif + aom** (via `--disable-avif`) - AVIF/HEIF support
- **libultrahdr** (via `--disable-uhdr`) - UltraHDR support

Note: libexif is GPLv2-compatible (LGPLv2.1+) and does not need to be excluded.

## Test plan

- [ ] Build with `--disable-avif --disable-uhdr` flags for GPLv2-compatible build
- [ ] Verify `versions.json` does not include heif, aom, or uhdr when disabled
- [ ] Run tests to ensure basic image operations still work

🤖 Generated with [Claude Code](https://claude.ai/code)