### PR TITLE
Add optional FITS support

### DIFF
--- a/src/bindings/vips-operators.cpp
+++ b/src/bindings/vips-operators.cpp
@@ -150,6 +150,19 @@ Image Image::gaussnoise(int width, int height, emscripten::val js_options)
     return out;
 }
 
+Image Image::fitsload(const std::string &filename, emscripten::val js_options)
+{
+    Image out;
+
+    Image::call("fitsload", nullptr,
+                (new Option)
+                    ->set("out", &out)
+                    ->set("filename", filename),
+                js_options);
+
+    return out;
+}
+
 Image Image::gifload(const std::string &filename, emscripten::val js_options)
 {
     Image out;
@@ -2099,6 +2112,15 @@ std::vector<double> Image::getpoint(int x, int y, emscripten::val js_options) co
                js_options);
 
     return out_array;
+}
+
+void Image::fitssave(const std::string &filename, emscripten::val js_options) const
+{
+    this->call("fitssave",
+               (new Option)
+                   ->set("in", *this)
+                   ->set("filename", filename),
+               js_options);
 }
 
 void Image::gifsave(const std::string &filename, emscripten::val js_options) const

--- a/src/bindings/vips-operators.h
+++ b/src/bindings/vips-operators.h
@@ -95,6 +95,8 @@ static Image gaussmat(double sigma, double min_ampl, emscripten::val js_options 
  */
 static Image gaussnoise(int width, int height, emscripten::val js_options = emscripten::val::null());
 
+static Image fitsload(const std::string &filename, emscripten::val js_options = emscripten::val::null());
+
 /**
  * Load gif with libnsgif.
  * @param filename Filename to load from.
@@ -1244,6 +1246,13 @@ Image gaussblur(double sigma, emscripten::val js_options = emscripten::val::null
  * @return Array of output values.
  */
 std::vector<double> getpoint(int x, int y, emscripten::val js_options = emscripten::val::null()) const;
+
+/**
+ * Save image to FITS file.
+ * @param filename Filename to save to.
+ * @param js_options Optional options.
+ */
+void fitssave(const std::string &filename, emscripten::val js_options = emscripten::val::null()) const;
 
 /**
  * Save as gif.

--- a/src/vips-emscripten.cpp
+++ b/src/vips-emscripten.cpp
@@ -1155,6 +1155,10 @@ EMSCRIPTEN_BINDINGS(my_module) {
         .class_function("gaussmat", optional_override([](double sigma, double min_ampl) {
                             return Image::gaussmat(sigma, min_ampl);
                         }))
+        .class_function("fitsload", &Image::fitsload)
+        .class_function("fitsload", optional_override([](const std::string &filename) {
+                            return Image::fitsload(filename);
+                        }))
         .class_function("gaussnoise", &Image::gaussnoise)
         .class_function("gaussnoise", optional_override([](int width, int height) {
                             return Image::gaussnoise(width, height);
@@ -1572,6 +1576,10 @@ EMSCRIPTEN_BINDINGS(my_module) {
         .function("getpoint", optional_override([](const Image &image, int x, int y) {
                       return image.getpoint(x, y);
                   }))
+        .function("fitssave", &Image::fitssave)
+        .function("fitssave", optional_override([](const Image &image, const std::string &filename) {
+                            image.fitssave(filename);
+                        }))
         .function("gifsave", &Image::gifsave)
         .function("gifsave", optional_override([](const Image &image, const std::string &filename) {
                       image.gifsave(filename);

--- a/test/unit/index.html
+++ b/test/unit/index.html
@@ -155,6 +155,7 @@
       console.log('TIFF support:'.padEnd(pad), have('tiffload') ? 'yes' : 'no');
       console.log('WebP support:'.padEnd(pad), have('webpload') ? 'yes' : 'no');
       console.log('GIF support:'.padEnd(pad), have('gifload') ? 'yes' : 'no');
+      console.log('FITS support:'.padEnd(pad), have('fitsload') ? 'yes' : 'no');
 
       console.log('SVG load:'.padEnd(pad), have('svgload') ? 'yes' : 'no');
 

--- a/test/unit/test_foreign.js
+++ b/test/unit/test_foreign.js
@@ -1030,6 +1030,19 @@ describe('foreign', () => {
     fileLoader('analyzeload', Helpers.analyzeFiles[0], analyzeValid);
   });
 
+  it('fits', function () {
+    // Needs FITS support
+    if (!Helpers.have('fitsload')) {
+      return this.skip();
+    }
+
+    // Create a simple image
+    const im = vips.Image.black(10, 10);
+    const im2 = im.add(128);
+
+    saveLoad('%s.fits', im2);
+  });
+
   it('csv', function () {
     saveLoad('%s.csv', mono);
   });


### PR DESCRIPTION
I need FITS support among others for an astronomy side project, and in the end wasm-vips / sharp was the easiest place to come back to and add it.

It's opt-in by default because I imagine most devs wouldn't want it in their bundle.